### PR TITLE
Close the results pane on new search

### DIFF
--- a/lib/element-finder.js
+++ b/lib/element-finder.js
@@ -74,6 +74,10 @@ export default {
     const files = utils.filesInDirectory();
     const pane = atom.workspace.getActivePane();
 
+    if (this.resultsView) {
+        pane.destroyItem(this.resultsView);
+    }
+
     this.resultsView = new ResultsView();
     pane.activateItem(pane.addItem(this.resultsView));
 


### PR DESCRIPTION
Great work on this, thanks a lot!

This is just a small enhancement to make it behave more like the "regular" find and replace, by using the same results pane instead of opening new ones for each search.
